### PR TITLE
Remove IGE - prefix from license headers

### DIFF
--- a/client-ai/AIs/__init__.py
+++ b/client-ai/AIs/__init__.py
@@ -3,17 +3,17 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #

--- a/client-ai/ai_handler.py
+++ b/client-ai/ai_handler.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/MiniMap.py
+++ b/client/osci/MiniMap.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/StarMapWidget.py
+++ b/client/osci/StarMapWidget.py
@@ -4,18 +4,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/SystemMapWidget.py
+++ b/client/osci/SystemMapWidget.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/__init__.py
+++ b/client/osci/__init__.py
@@ -3,17 +3,17 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #

--- a/client/osci/config.py
+++ b/client/osci/config.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/BuoyDlg.py
+++ b/client/osci/dialog/BuoyDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ChangeQtyDlg.py
+++ b/client/osci/dialog/ChangeQtyDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ColorDefinitionDlg.py
+++ b/client/osci/dialog/ColorDefinitionDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ConfirmDlg.py
+++ b/client/osci/dialog/ConfirmDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ConsoleDlg.py
+++ b/client/osci/dialog/ConsoleDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ConstrSelTechDlg.py
+++ b/client/osci/dialog/ConstrSelTechDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ConstrUpgradeDlg.py
+++ b/client/osci/dialog/ConstrUpgradeDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ConstructionDlg.py
+++ b/client/osci/dialog/ConstructionDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/DiplomacyDlg.py
+++ b/client/osci/dialog/DiplomacyDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/EmpireOverviewDlg.py
+++ b/client/osci/dialog/EmpireOverviewDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/EventsDlg.py
+++ b/client/osci/dialog/EventsDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ExceptionDlg.py
+++ b/client/osci/dialog/ExceptionDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/FleetCommandDlg.py
+++ b/client/osci/dialog/FleetCommandDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/FleetDlg.py
+++ b/client/osci/dialog/FleetDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/FleetMassRedirectionDlg.py
+++ b/client/osci/dialog/FleetMassRedirectionDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/FleetRedirectionDlg.py
+++ b/client/osci/dialog/FleetRedirectionDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/FleetScoutBloomDlg.py
+++ b/client/osci/dialog/FleetScoutBloomDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software 
+#  along with Outer Space; if not, write to the Free Software 
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/FleetSpecsDlg.py
+++ b/client/osci/dialog/FleetSpecsDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/FleetSplitDlg.py
+++ b/client/osci/dialog/FleetSplitDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/FleetsAnalysisDlg.py
+++ b/client/osci/dialog/FleetsAnalysisDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/FleetsOverviewDlg.py
+++ b/client/osci/dialog/FleetsOverviewDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/GalaxyRestartDlg.py
+++ b/client/osci/dialog/GalaxyRestartDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/GlobalQueuesDlg.py
+++ b/client/osci/dialog/GlobalQueuesDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/KeyModHelp.py
+++ b/client/osci/dialog/KeyModHelp.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/LocateDlg.py
+++ b/client/osci/dialog/LocateDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/MainGameDlg.py
+++ b/client/osci/dialog/MainGameDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/MainMenuDlg.py
+++ b/client/osci/dialog/MainMenuDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/MapOverlayDlg.py
+++ b/client/osci/dialog/MapOverlayDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/MessagesDlg.py
+++ b/client/osci/dialog/MessagesDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/MinefieldDlg.py
+++ b/client/osci/dialog/MinefieldDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/NewAccDlg.py
+++ b/client/osci/dialog/NewAccDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/NewAccountDlg.py
+++ b/client/osci/dialog/NewAccountDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/NewGlobalTaskDlg.py
+++ b/client/osci/dialog/NewGlobalTaskDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/NewMessageDlg.py
+++ b/client/osci/dialog/NewMessageDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/NewTaskDlg.py
+++ b/client/osci/dialog/NewTaskDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/OptionsDlg.py
+++ b/client/osci/dialog/OptionsDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/PlanetsAnalysisDlg.py
+++ b/client/osci/dialog/PlanetsAnalysisDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/PlanetsOverviewDlg.py
+++ b/client/osci/dialog/PlanetsOverviewDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ProblemsDlg.py
+++ b/client/osci/dialog/ProblemsDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ProgressDlg.py
+++ b/client/osci/dialog/ProgressDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/RenameFleetDlg.py
+++ b/client/osci/dialog/RenameFleetDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/RenameSysDlg.py
+++ b/client/osci/dialog/RenameSysDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ResearchDlg.py
+++ b/client/osci/dialog/ResearchDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/SearchDlg.py
+++ b/client/osci/dialog/SearchDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/ShowBuoyDlg.py
+++ b/client/osci/dialog/ShowBuoyDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/StarSystemDlg.py
+++ b/client/osci/dialog/StarSystemDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/StructTaskDlg.py
+++ b/client/osci/dialog/StructTaskDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/SystemOverviewDlg.py
+++ b/client/osci/dialog/SystemOverviewDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/TechInfoDlg.py
+++ b/client/osci/dialog/TechInfoDlg.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/Utils.py
+++ b/client/osci/dialog/Utils.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/_Template.py
+++ b/client/osci/dialog/_Template.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/dialog/__init__.py
+++ b/client/osci/dialog/__init__.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/gdata.py
+++ b/client/osci/gdata.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/handler.py
+++ b/client/osci/handler.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/messages.py
+++ b/client/osci/messages.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/res.py
+++ b/client/osci/res.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/client/osci/sequip.py
+++ b/client/osci/sequip.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/outerspace.py
+++ b/outerspace.py
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/BSDDBDatabase.py
+++ b/server/lib/ige/BSDDBDatabase.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/BSDDBSyncDatabase.py
+++ b/server/lib/ige/BSDDBSyncDatabase.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ClientMngr.py
+++ b/server/lib/ige/ClientMngr.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/Config.py
+++ b/server/lib/ige/Config.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/Const.py
+++ b/server/lib/ige/Const.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/Database.py
+++ b/server/lib/ige/Database.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/GameMngr.py
+++ b/server/lib/ige/GameMngr.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/GameServer.py
+++ b/server/lib/ige/GameServer.py
@@ -14,7 +14,7 @@
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 import os

--- a/server/lib/ige/IDataHolder.py
+++ b/server/lib/ige/IDataHolder.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/IMarshal.py
+++ b/server/lib/ige/IMarshal.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/IObject.py
+++ b/server/lib/ige/IObject.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/Index.py
+++ b/server/lib/ige/Index.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/IssueMngr.py
+++ b/server/lib/ige/IssueMngr.py
@@ -8,7 +8,7 @@
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.

--- a/server/lib/ige/LimitedClientMngr.py
+++ b/server/lib/ige/LimitedClientMngr.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/MetaServer.py
+++ b/server/lib/ige/MetaServer.py
@@ -14,7 +14,7 @@
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 import xmlrpclib

--- a/server/lib/ige/MsgMngr.py
+++ b/server/lib/ige/MsgMngr.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/RPCServer.py
+++ b/server/lib/ige/RPCServer.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/Transaction.py
+++ b/server/lib/ige/Transaction.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/__init__.py
+++ b/server/lib/ige/__init__.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/log.py
+++ b/server/lib/ige/log.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/Const.py
+++ b/server/lib/ige/ospace/Const.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/GalaxyGenerator.py
+++ b/server/lib/ige/ospace/GalaxyGenerator.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/GameMngr.py
+++ b/server/lib/ige/ospace/GameMngr.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IAIEDENPlayer.py
+++ b/server/lib/ige/ospace/IAIEDENPlayer.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IAIMutantPlayer.py
+++ b/server/lib/ige/ospace/IAIMutantPlayer.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IAIPiratePlayer.py
+++ b/server/lib/ige/ospace/IAIPiratePlayer.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IAIPlayer.py
+++ b/server/lib/ige/ospace/IAIPlayer.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IAIRenegadePlayer.py
+++ b/server/lib/ige/ospace/IAIRenegadePlayer.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IAlliance.py
+++ b/server/lib/ige/ospace/IAlliance.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IAsteroid.py
+++ b/server/lib/ige/ospace/IAsteroid.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IFleet.py
+++ b/server/lib/ige/ospace/IFleet.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IGalaxy.py
+++ b/server/lib/ige/ospace/IGalaxy.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/INature.py
+++ b/server/lib/ige/ospace/INature.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IPiratePlayer.py
+++ b/server/lib/ige/ospace/IPiratePlayer.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IPlanet.py
+++ b/server/lib/ige/ospace/IPlanet.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IPlayer.py
+++ b/server/lib/ige/ospace/IPlayer.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/ISystem.py
+++ b/server/lib/ige/ospace/ISystem.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IUniverse.py
+++ b/server/lib/ige/ospace/IUniverse.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/IWormHole.py
+++ b/server/lib/ige/ospace/IWormHole.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/Rules/Asteroid.xml
+++ b/server/lib/ige/ospace/Rules/Asteroid.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 -->

--- a/server/lib/ige/ospace/Rules/Obsolete.xml
+++ b/server/lib/ige/ospace/Rules/Obsolete.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 -->

--- a/server/lib/ige/ospace/Rules/QDev-Bonus.xml
+++ b/server/lib/ige/ospace/Rules/QDev-Bonus.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 -->

--- a/server/lib/ige/ospace/Rules/Setup.xml
+++ b/server/lib/ige/ospace/Rules/Setup.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 -->

--- a/server/lib/ige/ospace/Rules/TL1.xml
+++ b/server/lib/ige/ospace/Rules/TL1.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 -->

--- a/server/lib/ige/ospace/Rules/TL2.xml
+++ b/server/lib/ige/ospace/Rules/TL2.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 -->

--- a/server/lib/ige/ospace/Rules/TL3.xml
+++ b/server/lib/ige/ospace/Rules/TL3.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 -->

--- a/server/lib/ige/ospace/Rules/TL4.xml
+++ b/server/lib/ige/ospace/Rules/TL4.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 -->

--- a/server/lib/ige/ospace/Rules/TL5.xml
+++ b/server/lib/ige/ospace/Rules/TL5.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 -->

--- a/server/lib/ige/ospace/Rules/TL6.xml
+++ b/server/lib/ige/ospace/Rules/TL6.xml
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 #  TL6 developed by Michael Ney

--- a/server/lib/ige/ospace/Rules/Techs.py
+++ b/server/lib/ige/ospace/Rules/Techs.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/Rules/__init__.py
+++ b/server/lib/ige/ospace/Rules/__init__.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/Scanner.py
+++ b/server/lib/ige/ospace/Scanner.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/ShipUtils.py
+++ b/server/lib/ige/ospace/ShipUtils.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/TechHandlers.py
+++ b/server/lib/ige/ospace/TechHandlers.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/Utils.py
+++ b/server/lib/ige/ospace/Utils.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/ige/ospace/__init__.py
+++ b/server/lib/ige/ospace/__init__.py
@@ -3,17 +3,17 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #

--- a/server/lib/igeclient/IClient.py
+++ b/server/lib/igeclient/IClient.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/igeclient/IClientDB.py
+++ b/server/lib/igeclient/IClientDB.py
@@ -3,18 +3,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/server/lib/igeclient/__init__.py
+++ b/server/lib/igeclient/__init__.py
@@ -3,17 +3,17 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -5,18 +5,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/tools/osclient_cli.py
+++ b/tools/osclient_cli.py
@@ -4,18 +4,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 

--- a/tools/osclient_tui.py
+++ b/tools/osclient_tui.py
@@ -4,18 +4,18 @@
 #
 #  This file is part of Outer Space.
 #
-#  IGE - Outer Space is free software; you can redistribute it and/or modify
+#  Outer Space is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  IGE - Outer Space is distributed in the hope that it will be useful,
+#  Outer Space is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with IGE - Outer Space; if not, write to the Free Software
+#  along with Outer Space; if not, write to the Free Software
 #  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 


### PR DESCRIPTION
IGE - Outer Space was legacy name, no longer in use. Removal of this prefix is done to prevent confusion.