### PR TITLE
Tweaks based on test run

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ python2 ./outerspace.py server
 ```
 which will start server listening to default TCP port 9080 on all networks.
 
-*NOTE:* if you are running it for the first time, you have to prepare database with
-```
-python2 ./outerspace.py server --reset
-```
-and then run it again without the ```--reset``` flag.
 
 #### Galaxer
 Next step is to run Galaxer, in very similar fashion. Most common scenario is Galaxer running on the same machine as main server, in which case no arguments are necessary.

--- a/outerspace.py
+++ b/outerspace.py
@@ -102,7 +102,7 @@ parser_client.add_argument("--password", dest = "password",
 parser_client.add_argument("--heartbeat", dest = "heartbeat",
     type = int,
     metavar = "SECONDS",
-    default = 180,
+    default = 60,
     help = "Heartbeat for server connection"
 )
 


### PR DESCRIPTION
Reset is no longer needed when server is first started. Thus it is not necessary to mention it in installation guide. Also heartbeat is lowered to one minute, to be more compatible with fast ticking servers.