### PR TITLE
Update fleet range rings to 1, 1/2 and 1/3 range

### DIFF
--- a/client/osci/StarMapWidget.py
+++ b/client/osci/StarMapWidget.py
@@ -651,7 +651,7 @@ class StarMapWidget(Widget):
             turns = 100000
             if obj.operEn > 0: turns = obj.storEn / obj.operEn
             range = turns * obj.speed / Rules.turnsPerDay
-            self._fleetRanges[obj.oid] = (obj.x, obj.y, range, (range  * 0.75) / 2, (range  * 0.5) / 2, obj.speed * 6 / Rules.turnsPerDay, turns)
+            self._fleetRanges[obj.oid] = (obj.x, obj.y, range, range  / 2., range / 3., obj.speed * 6 / Rules.turnsPerDay, turns)
             info.append(_("Operational time: %s") % res.formatTime(turns))
         if hasattr(obj, 'target') and obj.target != OID_NONE:
             target = client.get(obj.target, noUpdate=1)


### PR DESCRIPTION
Original intention, why are the rings set in such a strange ranges
is lost, so I am changing it as 1/2 range is very useful imo, and
combined with 1/3 can be used even for estimation of fight viability.