### PR TITLE
Made blackholes always visible

### DIFF
--- a/server/lib/ige/ospace/IFleet.py
+++ b/server/lib/ige/ospace/IFleet.py
@@ -521,6 +521,7 @@ class IFleet(IObject):
             else:
                 systemID = targetID
             owner = tran.db[obj.owner]
+            targetSystem = tran.db[systemID]
             # validate that the player has actually scanned this system
             if systemID not in owner.validSystems:
                 raise GameException('You cannot find this system (never scanned).')
@@ -529,6 +530,11 @@ class IFleet(IObject):
             galaxy = tran.db[owner.galaxies[0]]
             if systemID not in galaxy.systems:
                 raise GameException('The target system is not in your galaxy.')
+            # because of universal visibility, fleets cannot target black holes
+            # it would make exploration too easy
+            if targetSystem.starClass[0] == 'b':
+                raise GameException('It would be too dangerous to go there.')
+
         obj.actions.insert(index, (action, targetID, aData))
         if index <= obj.actionIndex:
             obj.actionIndex += 1

--- a/server/lib/ige/ospace/Scanner.py
+++ b/server/lib/ige/ospace/Scanner.py
@@ -55,7 +55,7 @@ def computeMap(galaxyCmdObj, tran, galaxy):
     log.debug("SCAN2 Phase - starting")
 
     start = time.time()
-    map, fleets = generateMap(galaxyCmdObj, tran, galaxy)
+    _map, fleets, alwaysVisible = generateMap(galaxyCmdObj, tran, galaxy)
 
     # compute close fleets
     sectors, surroundingSectors = generateSectors(fleets, sectorSize = 1, size = 1)
@@ -65,15 +65,20 @@ def computeMap(galaxyCmdObj, tran, galaxy):
 
     # compute map
     start0 = time.time()
-    sectors, surroundingSectors = generateSectors(map, sectorSize = 5, size     = 10)
+    sectors, surroundingSectors = generateSectors(_map, sectorSize = 5, size     = 10)
     playerMaps = {}
-    processSectors(map, sectors, surroundingSectors, computeScanner, (playerMaps, signatures))
+    processSectors(_map, sectors, surroundingSectors, computeScanner, (playerMaps, signatures))
+
+    # add always visible items
+    for owner in playerMaps:
+        for visibleObject in alwaysVisible.values():
+            playerMaps[owner][visibleObject] = max(Rules.level1InfoScanPwr, playerMaps[owner].get(visibleObject, 0))
     stop = time.time()
     log.debug("Time    : %0.3f s" % (stop - start))
     log.debug("Time    : %0.3f s (including sector generation)" % (stop - start0))
     return playerMaps
 
-def processSectors(map, sectors, surroundingSectors, callable, args):
+def processSectors(_map, sectors, surroundingSectors, callable, args):
     while sectors:
         # get (and remove) random sector
         (sX, sY), sObjs = sectors.popitem()
@@ -87,10 +92,10 @@ def processSectors(map, sectors, surroundingSectors, callable, args):
                 objs.extend(sectors[sIdx])
         # check objects in current sector
         for obj1Idx in sObjs:
-            obj1 = map[obj1Idx]
+            obj1 = _map[obj1Idx]
             # with objects in surrounding sectors
             for obj2Idx in objs:
-                obj2 = map[obj2Idx]
+                obj2 = _map[obj2Idx]
                 callable(obj1, obj2, *args)
                 callable(obj2, obj1, *args)
             # with objects in current sector
@@ -98,18 +103,18 @@ def processSectors(map, sectors, surroundingSectors, callable, args):
                 # allow object scan on itself
                 if obj1Idx > obj2Idx:
                     continue
-                obj2 = map[obj2Idx]
+                obj2 = _map[obj2Idx]
                 callable(obj1, obj2, *args)
                 callable(obj2, obj1, *args)
 
-def generateSectors(map, sectorSize = 5, size = 10):
+def generateSectors(_map, sectorSize = 5, size = 10):
     # generate sector map
     sectors = {}
     # can be optimized to not include corner sectors
     surroundingSectors = range(-size / sectorSize, size / sectorSize + 1)
 
-    for i in map:
-        obj = map[i]
+    for i in _map:
+        obj = _map[i]
         sIdx = (int(obj.x / sectorSize), int(obj.y / sectorSize))
         if sIdx in sectors:
             sectors[sIdx].append(obj.oid)
@@ -119,15 +124,19 @@ def generateSectors(map, sectorSize = 5, size = 10):
     return sectors, surroundingSectors
 
 def generateMap(cmdObj, tran, galaxy):
-    map = {}
+    _map = {}
     fleets = {}
+    alwaysVisible = {}
     # all systems are part of the map
     for systemID in galaxy.systems:
         system = tran.db[systemID]
-        map[systemID] = system
+        # black holes are always visible, for easier orientation on the galaxy map
+        if system.starClass[0] == 'b':
+            alwaysVisible[systemID] = system
+        _map[systemID] = system
         # get mobile objects (fleet, ...)
         for objID in cmdObj.cmd(system).getObjectsInSpace(tran, system):
             obj = tran.db[objID]
-            map[objID] = obj
+            _map[objID] = obj
             fleets[objID] = obj
-    return map, fleets
+    return _map, fleets, alwaysVisible


### PR DESCRIPTION
Even though for new player it produces some excitement, not knowing
which part of galaxy he started in, most of the time it's just
annoying obstacle.

By this commit, black hole in the center (as well as any other, of
the same galaxy) is visible to all players, so they know where the
center is.

Fleets can no longer travel to the black hole.