### PR TITLE
Increased price of TL progressing technologies

### DIFF
--- a/server/lib/ige/ospace/Rules/TL1.xml
+++ b/server/lib/ige/ospace/Rules/TL1.xml
@@ -417,7 +417,7 @@
 	</technology>
 	<technology id="1990" symbol="BIONICTL2" name="DNA Manipulation">
 		<discovery
-			researchMod="1.00 + 1.00 + 3.00"
+			researchMod="1.00 + 1.00 + 5.00"
 			finishResearchHandler="finishResTLAdvance"
 			level="1"
 			data="B"
@@ -429,7 +429,7 @@
 	</technology>
 	<technology id="1991" symbol="HUMANTL2" name="Human Brain Improvements">
 		<discovery
-			researchMod="1.00 + 1.00 + 3.00"
+			researchMod="1.00 + 1.00 + 5.00"
 			finishResearchHandler="finishResTLAdvance"
 			level="1"
 			data="H"
@@ -441,7 +441,7 @@
 	</technology>
 	<technology id="1992" symbol="ROBOTTL2" name="Advanced Robotics">
 		<discovery
-			researchMod="1.00 + 1.00 + 3.00"
+			researchMod="1.00 + 1.00 + 5.00"
 			finishResearchHandler="finishResTLAdvance"
 			level="1"
 			data="C"

--- a/server/lib/ige/ospace/Rules/TL2.xml
+++ b/server/lib/ige/ospace/Rules/TL2.xml
@@ -471,7 +471,7 @@
 	</technology>
 	<technology id="2990" symbol="BIONICTL3" name="Human Body Enhancements">
 		<discovery
-			researchMod="1.00 + 1.00 + 3.00"
+			researchMod="1.00 + 1.00 + 5.00 + 1.00"
 			finishResearchHandler="finishResTLAdvance"
 			level="2"
 			data="B"
@@ -483,7 +483,7 @@
 	</technology>
 	<technology id="2991" symbol="HUMANTL3" name="Brain Enhancements">
 		<discovery
-			researchMod="1.00 + 1.00 + 3.00"
+			researchMod="1.00 + 1.00 + 5.00 + 1.00"
 			finishResearchHandler="finishResTLAdvance"
 			level="2"
 			data="H"
@@ -495,7 +495,7 @@
 	</technology>
 	<technology id="2992" symbol="ROBOTTL3" name="Cyber Implants">
 		<discovery
-			researchMod="1.00 + 1.00 + 3.00"
+			researchMod="1.00 + 1.00 + 5.00 + 1.00"
 			finishResearchHandler="finishResTLAdvance"
 			level="2"
 			data="C"

--- a/server/lib/ige/ospace/Rules/TL3.xml
+++ b/server/lib/ige/ospace/Rules/TL3.xml
@@ -744,7 +744,7 @@
 	</technology>
 	<technology id="3990" symbol="BIONICTL4" name="DNA Synthesis">
 		<discovery
-			researchMod="1.00 + 1.00 + 3.00"
+			researchMod="1.00 + 1.00 + 5.00"
 			finishResearchHandler="finishResTLAdvance"
 			level="3"
 			data="B"
@@ -756,7 +756,7 @@
 	</technology>
 	<technology id="3991" symbol="HUMANTL4" name="Mind Linking">
 		<discovery
-			researchMod="1.00 + 1.00 + 3.00"
+			researchMod="1.00 + 1.00 + 5.00"
 			finishResearchHandler="finishResTLAdvance"
 			level="3"
 			data="H"
@@ -768,7 +768,7 @@
 	</technology>
 	<technology id="3992" symbol="ROBOTTL4" name="Artificial Inteligence">
 		<discovery
-			researchMod="1.00 + 1.00 + 3.00"
+			researchMod="1.00 + 1.00 + 5.00"
 			finishResearchHandler="finishResTLAdvance"
 			level="3"
 			data="C"

--- a/server/lib/ige/ospace/Rules/TL4.xml
+++ b/server/lib/ige/ospace/Rules/TL4.xml
@@ -1031,7 +1031,7 @@
     </technology>
     <technology id="4990" symbol="BIONICTL5" name="Selective Mutations">
         <discovery
-            researchMod="1.00 + 1.00 + 3.00"
+            researchMod="1.00 + 1.00 + 5.00"
             finishResearchHandler="finishResTLAdvance"
             level="4"
             data="B"
@@ -1043,7 +1043,7 @@
     </technology>
     <technology id="4991" symbol="HUMANTL5" name="Super Human">
         <discovery
-            researchMod="1.00 + 1.00 + 3.00"
+            researchMod="1.00 + 1.00 + 5.00"
             finishResearchHandler="finishResTLAdvance"
             level="4"
             data="H"
@@ -1055,7 +1055,7 @@
     </technology>
     <technology id="4992" symbol="ROBOTTL5" name="Artificial Brain Software">
         <discovery
-            researchMod="1.00 + 1.00 + 3.00"
+            researchMod="1.00 + 1.00 + 5.00"
             finishResearchHandler="finishResTLAdvance"
             level="4"
             data="C"

--- a/server/lib/ige/ospace/Rules/TL5.xml
+++ b/server/lib/ige/ospace/Rules/TL5.xml
@@ -1455,7 +1455,7 @@
 	</technology>
     <technology id="5990" symbol="BIONICTL6" name="Self Pollination">
         <discovery
-            researchMod="1.00 + 1.00 + 3.00"
+            researchMod="1.00 + 1.00 + 5.00"
             finishResearchHandler="finishResTLAdvance"
             level="5"
             data="B"
@@ -1468,7 +1468,7 @@
     </technology>
     <technology id="5991" symbol="HUMANTL6" name="Mental Chameleonism">
         <discovery
-            researchMod="1.00 + 1.00 + 3.00"
+            researchMod="1.00 + 1.00 + 5.00"
             finishResearchHandler="finishResTLAdvance"
             level="5"
             data="H"
@@ -1481,7 +1481,7 @@
     </technology>
     <technology id="5992" symbol="ROBOTTL6" name="High Energy Robotic Brains">
         <discovery
-            researchMod="1.00 + 1.00 + 3.00"
+            researchMod="1.00 + 1.00 + 5.00"
             finishResearchHandler="finishResTLAdvance"
             level="5"
             data="C"


### PR DESCRIPTION
Rushing through tech tree and skipping less viable tech levels is now
very safe way to play the game. By increasing this threshold, I want to
make the risk while rushing a bit higher.

Slightly bigger bumb in case of technology to TL3, because this TL is so
useful, it's worth the wait (rush to TL3 is most obvious of the rushes)