### PR TITLE
Ensure resource planets are large

### DIFF
--- a/server/lib/ige/ospace/GalaxyGenerator.py
+++ b/server/lib/ige/ospace/GalaxyGenerator.py
@@ -361,6 +361,13 @@ def generateGalaxy2(galaxyType=None):
                 if planet.type in ("D", "R", "C"):
                     planets.append(planet)
             planet = random.choice(planets)
+            # now make sure resources are placed on big enough planets
+            # to promote more strategic and less tactical fights over them
+            # and ensure some minimal barrier is there for player to
+            # overcome
+            planet.diameter = dice(1, 6, 12) * 1000
+            planet.maxSlots = int(planet.diameter / 1000.)
+            planet.slots = dice(1, 2, 7)
             planet.strategicRes = key
             system = planet.compOf
             system.hasSR = 1


### PR DESCRIPTION
To ensure there is certain barrier for players to overcome, plus
promote more strategic fighting over them (as small planets are
very hard to defend, and tactical just-in-time snatching is viable)