### PR TITLE
Option to manually set bio/en reserves disabled.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -3,6 +3,11 @@
 
 [2017-07-09]
 - Hovering over planets in system dialog shows detailed info [dahaic]
+- Option to manually set bio/en reserves disabled. [dahaic]
+  This feature was too micromanagerial to do any good. And for new players
+  it usually meant to shoot themselves in a foot when they tried to use it.
+  From now on only automated reserve will be supported, which means 6 turns
+  of consumption.
 
 [2017-07-08]
 - Revision bump to 0.5.70 [dahaic]

--- a/client/osci/dialog/StarSystemDlg.py
+++ b/client/osci/dialog/StarSystemDlg.py
@@ -487,24 +487,6 @@ class StarSystemDlg:
             self.win.vPCSRes.text = _(gdata.stratRes[planet.plStratRes])
         else:
             self.win.vPCSRes.text = _("?")
-        # min storage
-        # auto storage regulation?
-        if hasattr(planet, 'minBio'):
-            self.win.setTagAttr('minStor', 'visible', 1)
-            text = _("Minimal storage %d.") % planet.minBio
-            self.win.vPCMinBio.text = str(planet.minBio)
-            self.win.vPCMinBio.tooltip = text
-            self.win.vPCMinBio.statustip = text
-            text = _("Minimal storage %d") % planet.minEn
-            self.win.vPCMinEn.text = str(planet.minEn)
-            self.win.vPCMinEn.tooltip = text
-            self.win.vPCMinEn.statustip = text
-            self.win.vPCAutoMinStor.enabled = 1
-            self.win.vPCAutoMinStor.pressed = planet.autoMinStor
-        else:
-            self.win.setTagAttr('minStor', 'visible', 0)
-            self.win.vPCAutoMinStor.enabled = 0
-            self.win.vPCAutoMinStor.pressed = 0
         # show info
         self.showPlInfo()
 
@@ -1128,41 +1110,6 @@ class StarSystemDlg:
     def onViewMinefield(self, widget, action, data):
         self.minefieldDlg.display(self.systemID)
 
-    def onChangeMinStorage(self, widget, action, data):
-        try:
-            bio = int(self.win.vPCMinBio.text)
-        except ValueError:
-            self.win.setStatus(_('Enter number into biomatter min. reserve field.'))
-            return
-        try:
-            en = int(self.win.vPCMinEn.text)
-        except ValueError:
-            self.win.setStatus(_('Enter number into energy min. reserve field.'))
-            return
-        try:
-            self.win.setStatus(_('Executing CHANGE RESERVES LIMITS command...'))
-            planet = client.get(self.planetID, noUpdate = 1)
-            client.cmdProxy.setMinStorage(self.planetID, bio, en)
-            planet.minBio = bio
-            planet.minMin = min
-            planet.minEn = en
-            self.showPlanet()
-            self.win.setStatus(_('Command has been executed.'))
-        except ige.GameException, e:
-            self.win.setStatus(e.args[0])
-            return
-
-    def onAutoMinStorage(self, widget, action, data):
-        try:
-            self.win.setStatus(_('Executing SWITCH AUTOMATIC REGULATION command...'))
-            planet = client.get(self.planetID, noUpdate = 1)
-            planet.autoMinStor = client.cmdProxy.setAutoMinStorage(self.planetID, not planet.autoMinStor)
-            self.showPlanet()
-            self.win.setStatus(_('Command has been executed.'))
-        except ige.GameException, e:
-            self.win.setStatus(e.args[0])
-            return
-
     def onLocateSystem(self, widget, action, data):
         self.locateDlg.display(self.systemID, self)
 
@@ -1309,24 +1256,10 @@ class StarSystemDlg:
             align = ui.ALIGN_W, tags = ['pl'])
         ui.Label(self.win, layout = (5, 16, 5, 1), id = 'vPCStorBio',
             align = ui.ALIGN_E, tags = ['pl'])
-        ui.Label(self.win, layout = (10, 16, 5, 1), text = _('Min. reserve'),
-            align = ui.ALIGN_W, tags = ['pl', 'minStor'])
-        ui.Entry(self.win, layout = (15, 16, 5, 1), id = 'vPCMinBio',
-            align = ui.ALIGN_E, tags = ['pl', 'minStor'])
         ui.Label(self.win, layout = (0, 17, 5, 1), text = _('Energy'),
             align = ui.ALIGN_W, tags = ['pl'])
         ui.Label(self.win, layout = (5, 17, 5, 1), id = 'vPCStorEn',
             align = ui.ALIGN_E, tags = ['pl'])
-        ui.Label(self.win, layout = (10, 17, 5, 1), text = _('Min. reserve'),
-            align = ui.ALIGN_W, tags = ['pl', 'minStor'])
-        ui.Entry(self.win, layout = (15, 17, 5, 1), id = 'vPCMinEn',
-            align = ui.ALIGN_E, tags = ['pl', 'minStor'])
-        ui.Button(self.win, layout = (15, 18, 4, 1), text = _('Change'),
-            tags = ['pl', 'minStor'], action = 'onChangeMinStorage')
-        ui.Button(self.win, layout = (19, 18, 1, 1), text = _('A'),
-            tags = ['pl', 'minStor'], action = 'onAutoMinStorage', toggle = 1,
-            tooltip = _('Automatic regulation on/off.'), id = 'vPCAutoMinStor',
-            statustip = _('Automatic regulation on/off.'))
         ui.Label(self.win, layout = (0, 19, 5, 1), text = _('Free workers'),
             align = ui.ALIGN_W, tags = ['pl'])
         ui.Label(self.win, layout = (5, 19, 5, 1), id = 'vPCUnempl',

--- a/server/lib/ige/ospace/IPlanet.py
+++ b/server/lib/ige/ospace/IPlanet.py
@@ -251,24 +251,6 @@ class IPlanet(IObject):
     changeOwner.public = 1
     changeOwner.accLevel = AL_ADMIN
 
-    def setMinStorage(self, tran, obj, bio, en):
-        if bio < 0 or en < 0:
-            raise GameException('Values must be equal or greater than zero.')
-        obj.minBio = bio
-        obj.minEn = en
-
-    setMinStorage.public = 1
-    setMinStorage.accLevel = AL_FULL
-
-    def setAutoMinStorage(self, tran, obj, on):
-        if on != 0 and on != 1:
-            raise GameException('Must be 0 or 1')
-        obj.autoMinStor = on
-        return obj.autoMinStor
-
-    setAutoMinStorage.public = 1
-    setAutoMinStorage.accLevel = AL_FULL
-
     def setStructOn(self, tran, obj, slotIdx, on):
         if slotIdx >= len(obj.slots) or slotIdx < 0:
             raise GameException('No such structure.')
@@ -891,6 +873,9 @@ class IPlanet(IObject):
     def update(self, tran, obj):
         # clean up negative build queues and fix missing demolishStruct keys
         loopAgain = True
+        # 0.5.70 -> 0.5.71 removing option to set reserves, auto reserve only option
+        obj.autoMinStor = 1
+
         while loopAgain:
             deletedKey = False
             for key in range(0,len(obj.prodQueue)):


### PR DESCRIPTION
This feature was too micromanagerial to do any good. And for new players
it usually meant to shoot themselves in a foot when they tried to use it.
From now on only automated reserve will be supported, which means 6 turns
of consumption.