### PR TITLE
Lower automatic reserve to 2 turns from 6

### DIFF
--- a/server/lib/ige/ospace/Rules/__init__.py
+++ b/server/lib/ige/ospace/Rules/__init__.py
@@ -127,8 +127,7 @@ bioBaseStor = 4800
 minBaseStor = 4800
 enBaseStor = 4800
 
-autoMinStorTurns = 6
-autoReqStorTurns = 1
+autoMinStorTurns = 2
 
 maxPopReserve = 1.125
 tlPopReserve = 250


### PR DESCRIPTION
As it is no longer manually adjustable, let's keep it more obvious,
so fast growing colonies can support each other more easily.