### PR TITLE
Fix Mutagen Synthesis, no messages for normal synthesis

### DIFF
--- a/server/lib/ige/ospace/Rules/TL2.xml
+++ b/server/lib/ige/ospace/Rules/TL2.xml
@@ -463,7 +463,7 @@
 		/>
 		<project
 			globalDisabled="0"
-			buildProd="9600"
+			buildProd="960"
 			data="100"
 			finishConstrHandler="finishProjectNF"
 		/>

--- a/server/lib/ige/ospace/TechHandlers.py
+++ b/server/lib/ige/ospace/TechHandlers.py
@@ -207,7 +207,6 @@ def finishProjectNF(tran, source, target, tech):
         owner = tran.db[target.owner]
         stratRes = int(tech.data)
         owner.stratRes[stratRes] = owner.stratRes.get(stratRes, 0) + SR_AMOUNT_SMALL
-        Utils.sendMessage(tran, target, MSG_EXTRACTED_STRATRES, target.oid, stratRes)
 
 ## Antimatter transmutation
 def finishProjectNF2(tran, source, target, tech):


### PR DESCRIPTION
There was an omission - Mutagen Synthesys still priced at 9600, even though
there is only 0.1 produced by the task. This is now fixed.

Messages spammed every 960 CP are not really user friendly, thus this
disables them as well. For antimatter synthesis, message is still printed,
as well as for weekly planetary produce.