### PR TITLE
Lvl 1 tech description fix

### DIFF
--- a/client/osci/dialog/TechInfoDlg.py
+++ b/client/osci/dialog/TechInfoDlg.py
@@ -326,7 +326,6 @@ class TechInfoDlg:
 
     def _getPlayerRace(self):
         player = client.getPlayer()
-        raceChoosen = None
         if player.techLevel > 1:
             return player.race
 

--- a/client/osci/dialog/TechInfoDlg.py
+++ b/client/osci/dialog/TechInfoDlg.py
@@ -327,12 +327,14 @@ class TechInfoDlg:
     def _getPlayerRace(self):
         player = client.getPlayer()
         raceChoosen = None
-        if player.techLevel == 1:
-            techID = set(player.techs).intersection(set([1990, 1991, 1992])).pop()  # these are the race-selecting techs
-            raceChoosen = client.getTechInfo(techID).data
+        if player.techLevel > 1:
+            return player.race
+
+        tech = set(player.techs).intersection(set([1990, 1991, 1992]))
+        if len(tech):
+            return client.getTechInfo(tech.pop()).data
         else:
-            raceChoosen = player.race
-        return raceChoosen
+            return None
 
     def _researchEnablement(self, tech):
         descr = []


### PR DESCRIPTION
When no race choosing tech was researched, it was impossible to show info about any already researched tech as obtaining of the player race would crash. This pull request fixes the obtaining of player race and in turn also allows showing the tech info. 